### PR TITLE
Table types and constraints

### DIFF
--- a/console/Create.cs
+++ b/console/Create.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using SchemaZen.model;
 
@@ -11,38 +12,36 @@ namespace SchemaZen.console {
 		public override int Run(string[] remainingArguments) {
 			var db = CreateDatabase();
 			if (!Directory.Exists(db.Dir)) {
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.WriteLine("Snapshot dir {0} does not exist.", db.Dir);
-				Console.ForegroundColor = ConsoleColor.White;
+				Log(TraceLevel.Error, string.Format("Snapshot dir {0} does not exist.", db.Dir));
 				return 1;
 			}
 
-			if (DBHelper.DbExists(db.Connection) && !Overwrite) {
-				if (!ConsoleQuestion.AskYN(string.Format("{0} {1} already exists - do you want to drop it", Server, DbName))) {
-					Console.WriteLine("Create command cancelled.");
-					return 1;
+			if (!Overwrite) {
+				Log(TraceLevel.Verbose, "Checking if database already exists...");
+				if (DBHelper.DbExists(db.Connection)) {
+					if (!ConsoleQuestion.AskYN(string.Format("{0} {1} already exists - do you want to drop it", Server, DbName))) {
+						Console.WriteLine("Create command cancelled.");
+						return 1;
+					}
+					Overwrite = true;
 				}
-				Overwrite = true;
 			}
 
 			try {
-				db.CreateFromDir(Overwrite);
-				Console.WriteLine();
-				Console.WriteLine("Database created successfully.");
+				db.CreateFromDir(Overwrite, Log);
+				Log(TraceLevel.Info, Environment.NewLine + "Database created successfully.");
 			} catch (BatchSqlFileException ex) {
-				Console.WriteLine();
-				Console.WriteLine(@"Create completed with the following errors:");
-				Console.ForegroundColor = ConsoleColor.Red;
-				foreach (var e in ex.Exceptions) {
-					Console.WriteLine(@"{0} (Line {1}): {2}", e.FileName.Replace("/", "\\"), e.LineNumber, e.Message);
+				Log(TraceLevel.Info, Environment.NewLine + "Create completed with the following errors:");
+				foreach (var e in ex.Exceptions)
+				{
+					Log(TraceLevel.Info, string.Format("- {0} (Line {1}):", e.FileName.Replace("/", "\\"), e.LineNumber));
+					Log(TraceLevel.Error, string.Format(" {0}", e.Message));
 				}
-				Console.ForegroundColor = ConsoleColor.White;
 				return -1;
 			} catch (SqlFileException ex) {
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.Write(@"An unexpected SQL error occurred while executing scripts, and the process wasn't completed.
-{0} (Line {1}): {2}", ex.FileName.Replace("/", "\\"), ex.LineNumber, ex.Message);
-				Console.ForegroundColor = ConsoleColor.White;
+				Log(TraceLevel.Info, Environment.NewLine + string.Format(@"An unexpected SQL error occurred while executing scripts, and the process wasn't completed.
+{0} (Line {1}):", ex.FileName.Replace("/", "\\"), ex.LineNumber));
+				Log(TraceLevel.Error, ex.Message);
 				return -1;
 			}
 

--- a/console/DbCommand.cs
+++ b/console/DbCommand.cs
@@ -1,4 +1,6 @@
-﻿using System.Data.SqlClient;
+﻿using System;
+using System.Data.SqlClient;
+using System.Diagnostics;
 using ManyConsole;
 using NDesk.Options;
 using SchemaZen.model;
@@ -21,6 +23,10 @@ namespace SchemaZen.console {
 				"o|overwrite=",
 				"Overwrite existing target without prompt.",
 				o => Overwrite = o != null);
+			HasOption(
+				"v|verbose=",
+				"Enable verbose log messages.",
+				o => Verbose = o != null);
 		}
 
 		protected string Server { get; set; }
@@ -29,6 +35,7 @@ namespace SchemaZen.console {
 		protected string Pass { get; set; }
 		protected string ScriptDir { get; set; }
 		protected bool Overwrite { get; set; }
+		protected bool Verbose { get; set; }
 
 		protected Database CreateDatabase() {
 			var builder = new SqlConnectionStringBuilder {
@@ -44,6 +51,31 @@ namespace SchemaZen.console {
 				Connection = builder.ToString(),
 				Dir = ScriptDir
 			};
+		}
+
+		protected void Log(TraceLevel level, string message) {
+			var prevColor = Console.ForegroundColor;
+
+			switch (level)
+			{
+				case TraceLevel.Error:
+					Console.ForegroundColor = ConsoleColor.Red;
+					break;
+				case TraceLevel.Verbose:
+					if (!Verbose)
+						return;
+					break;
+				case TraceLevel.Warning:
+					//Console.ForegroundColor = ConsoleColor.Red;
+					break;
+			}
+
+			if (message.EndsWith("\r"))
+				Console.Write(message);
+			else
+				Console.WriteLine(message);
+
+			Console.ForegroundColor = prevColor;
 		}
 	}
 }

--- a/console/Properties/AssemblyInfo.cs
+++ b/console/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.3.2.0")]
-[assembly: AssemblyFileVersion("1.3.2.0")]
+[assembly: AssemblyVersion("1.3.3.0")]
+[assembly: AssemblyFileVersion("1.3.3.0")]

--- a/console/Properties/AssemblyInfo.cs
+++ b/console/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.2.0")]
+[assembly: AssemblyFileVersion("1.3.2.0")]

--- a/console/console.csproj
+++ b/console/console.csproj
@@ -130,7 +130,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)\packages\ilmerge.2.13.0307\ilmerge /target:exe /out:SchemaZen.exe console.exe model.dll ManyConsole.dll NDesk.Options.dll
+    <PostBuildEvent>"$(SolutionDir)\packages\ilmerge.2.13.0307\ilmerge" /target:exe /out:SchemaZen.exe console.exe model.dll ManyConsole.dll NDesk.Options.dll
 </PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/model/Column.cs
+++ b/model/Column.cs
@@ -133,6 +133,7 @@ namespace SchemaZen.model {
 					return typeof (int);
 				case "uniqueidentifier":
 					return typeof (Guid);
+				case "binary":
 				case "varbinary":
 				case "image":
 					return typeof (byte[]);

--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -36,8 +36,8 @@ namespace SchemaZen.model {
 				}
 				return sql;
 			}
-			return string.Format("CONSTRAINT [{0}] {1} {2} ([{3}])", Name, Type, ClusteredText,
-				string.Join("], [", Columns.ToArray()));
+			return (Table.IsType ? string.Empty : string.Format("CONSTRAINT [{0}] ", Name)) +
+				string.Format("{0} {1} ([{2}])", Type, ClusteredText, string.Join("], [", Columns.ToArray()));
 		}
 	}
 }

--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -23,7 +23,7 @@ namespace SchemaZen.model {
 		}
 
 		public string UniqueText {
-			get { return !Unique ? "" : "UNIQUE"; }
+			get { return Type != "PRIMARY KEY" && !Unique ? "" : "UNIQUE"; }
 		}
 
 		public string ScriptCreate() {

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -140,6 +140,7 @@ namespace SchemaZen.model {
 
 		public void Load() {
 			Tables.Clear();
+			TableTypes.Clear();
 			Routines.Clear();
 			ForeignKeys.Clear();
 			DataTables.Clear();

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -1104,8 +1104,6 @@ where name = @dbname
 				}
 				try {
 					t.ImportData(Connection, fi.FullName);
-				} catch (DataException ex) {
-					throw new DataFileException(ex.Message, fi.FullName, ex.LineNumber);
 				} catch (SqlBatchException ex) {
 					throw new DataFileException(ex.Message, fi.FullName, ex.LineNumber);
 				} catch (Exception ex) {

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -142,6 +142,7 @@ namespace SchemaZen.model {
 			Tables.Clear();
 			Routines.Clear();
 			ForeignKeys.Clear();
+			DataTables.Clear();
 			ViewIndexes.Clear();
 			Assemblies.Clear();
 			Users.Clear();

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -1067,6 +1067,8 @@ where name = @dbname
 		}
 
 		public void ExportData(string tableHint = null, Action<TraceLevel, string> log = null) {
+			if (!DataTables.Any())
+				return;
 			var dataDir = Dir + "/data";
 			if (!Directory.Exists(dataDir)) {
 				Directory.CreateDirectory(dataDir);
@@ -1100,12 +1102,13 @@ where name = @dbname
 		#region Create
 
 		public void ImportData(Action<TraceLevel, string> log = null) {
+			if (log == null) log = (tl, s) => { };
+
 			var dataDir = Dir + "\\data";
 			if (!Directory.Exists(dataDir)) {
+				log(TraceLevel.Verbose, "No data to import.");
 				return;
 			}
-
-			if (log == null) log = (tl, s) => { };
 
 			log(TraceLevel.Verbose, "Loading database schema...");
 			Load(); // load the schema first so we can import data

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -142,7 +142,6 @@ namespace SchemaZen.model {
 			Tables.Clear();
 			Routines.Clear();
 			ForeignKeys.Clear();
-			DataTables.Clear();
 			ViewIndexes.Clear();
 			Assemblies.Clear();
 			Users.Clear();

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -121,7 +121,7 @@ namespace SchemaZen.model {
 
 		private static readonly string[] dirs = {
 			"tables", "foreign_keys", "assemblies", "functions", "procedures", "triggers",
-			"views", "xmlschemacollections", "data", "users", "synonyms"
+			"views", "xmlschemacollections", "data", "users", "synonyms", "table_types"
 		};
 
 		private void SetPropOnOff(string propName, object dbVal) {
@@ -442,8 +442,7 @@ order by fk.name, fkc.constraint_column_id
 					var c = t.FindConstraint((string) dr["indexName"]);
 					if (c == null) {
 						c = new Constraint((string) dr["indexName"], "", "");
-						t.Constraints.Add(c);
-						c.Table = t;
+						t.AddConstraint(c);
 
 						if ((string) dr["baseType"] == "V")
 							ViewIndexes.Add(c);

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -573,7 +573,7 @@ order by fk.name, fkc.constraint_column_id
 					CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END as IS_NULLABLE,
 					CASE WHEN t.name = 'nvarchar' THEN CAST(c.max_length as int)/2 ELSE CAST(c.max_length as int) END as CHARACTER_MAXIMUM_LENGTH,
 					c.precision as NUMERIC_PRECISION,
-					c.scale as NUMERIC_SCALE,
+					CAST(c.scale as int) as NUMERIC_SCALE,
 					CASE WHEN c.is_rowguidcol = 1 THEN 'YES' ELSE 'NO' END as IS_ROW_GUID_COL
 				from sys.columns c
 					inner join sys.table_types tt

--- a/model/Exceptions.cs
+++ b/model/Exceptions.cs
@@ -63,22 +63,4 @@ namespace SchemaZen.model {
 			get { return _lineNumber; }
 		}
 	}
-
-	public class DataException : Exception {
-		private readonly int _lineNumber;
-		private readonly string _message;
-
-		public DataException(string message, int lineNumber) {
-			_message = message;
-			_lineNumber = lineNumber;
-		}
-
-		public override string Message {
-			get { return _message; }
-		}
-
-		public int LineNumber {
-			get { return _lineNumber; }
-		}
-	}
 }

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -214,7 +214,7 @@ end
 						var fields = (new String(line.ToArray())).Split(new[] { fieldSeparator }, StringSplitOptions.None);
 						if (fields.Length != dt.Columns.Count)
 						{
-							throw new DataException("Incorrect number of columns", linenumber);
+							throw new DataFileException("Incorrect number of columns", filename, linenumber);
 						}
 						for (var j = 0; j < fields.Length; j++)
 						{
@@ -225,7 +225,7 @@ end
 							}
 							catch (FormatException ex)
 							{
-								throw new DataException(string.Format("{0} at column {1}", ex.Message, j + 1), linenumber);
+								throw new DataFileException(string.Format("{0} at column {1}", ex.Message, j + 1), filename, linenumber);
 							}
 						}
 						dt.Rows.Add(row);

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -143,7 +143,7 @@ end
 								if (dr[c.Name] is DBNull)
 									data.Write(nullValue);
 								else if (dr[c.Name] is byte[])
-									data.Write(new SoapHexBinary((byte[]) dr[c.Name]).ToString());
+									data.Write(new SoapHexBinary((byte[])dr[c.Name]).ToString());
 								else
 									data.Write(dr[c.Name].ToString()
 										.Replace(fieldSeparator, escapeFieldSeparator)
@@ -164,29 +164,24 @@ end
 
 			var dt = new DataTable();
 			var cols = Columns.Items.Where(c => string.IsNullOrEmpty(c.ComputedDefinition)).ToArray();
-			foreach (var c in cols)
-			{
+			foreach (var c in cols) {
 				dt.Columns.Add(new DataColumn(c.Name, c.SqlTypeToNativeType()));
 			}
 
 			var linenumber = 0;
 			var batch_rows = 0;
-			using (var bulk = new SqlBulkCopy(conn, SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock))
-			{
+			using (var bulk = new SqlBulkCopy(conn, SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock)) {
 				foreach (var colName in dt.Columns.OfType<DataColumn>().Select(c => c.ColumnName))
 					bulk.ColumnMappings.Add(colName, colName);
 				bulk.DestinationTableName = string.Format("[{0}].[{1}]", Owner, Name);
 
-				using (var file = new StreamReader(filename))
-				{
+				using (var file = new StreamReader(filename)) {
 					var line = new List<char>();
-					while (file.Peek() >= 0)
-					{
+					while (file.Peek() >= 0) {
 						var rowsep_cnt = 0;
 						line.Clear();
 
-						while (file.Peek() >= 0)
-						{
+						while (file.Peek() >= 0) {
 							var ch = (char)file.Read();
 							line.Add(ch);
 
@@ -195,8 +190,7 @@ end
 							else
 								rowsep_cnt = 0;
 
-							if (rowsep_cnt == rowSeparator.Length)
-							{
+							if (rowsep_cnt == rowSeparator.Length) {
 								// Remove rowseparator from line
 								line.RemoveRange(line.Count - rowSeparator.Length, rowSeparator.Length);
 								break;
@@ -212,26 +206,20 @@ end
 
 						var row = dt.NewRow();
 						var fields = (new String(line.ToArray())).Split(new[] { fieldSeparator }, StringSplitOptions.None);
-						if (fields.Length != dt.Columns.Count)
-						{
+						if (fields.Length != dt.Columns.Count) {
 							throw new DataFileException("Incorrect number of columns", filename, linenumber);
 						}
-						for (var j = 0; j < fields.Length; j++)
-						{
-							try
-							{
+						for (var j = 0; j < fields.Length; j++) {
+							try {
 								row[j] = ConvertType(cols[j].Type,
 									fields[j].Replace(escapeRowSeparator, rowSeparator).Replace(escapeFieldSeparator, fieldSeparator));
-							}
-							catch (FormatException ex)
-							{
+							} catch (FormatException ex) {
 								throw new DataFileException(string.Format("{0} at column {1}", ex.Message, j + 1), filename, linenumber);
 							}
 						}
 						dt.Rows.Add(row);
 
-						if (batch_rows == rowsInBatch)
-						{
+						if (batch_rows == rowsInBatch) {
 							batch_rows = 0;
 							bulk.WriteToServer(dt);
 							dt.Clear();
@@ -285,7 +273,7 @@ end
 		public bool IsDiff {
 			get {
 				return ColumnsAdded.Count + ColumnsDropped.Count + ColumnsDiff.Count + ConstraintsAdded.Count +
-				       ConstraintsChanged.Count + ConstraintsDeleted.Count > 0;
+					   ConstraintsChanged.Count + ConstraintsDeleted.Count > 0;
 			}
 		}
 

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -33,7 +33,7 @@ end
 		private const string rowSeparator = "\r\n";
 		private const string escapeRowSeparator = "--SchemaZenRowSeparator--";
 		private const string nullValue = "--SchemaZenNull--";
-		private const int rowsInBatch = 15000;
+		public const int rowsInBatch = 15000;
 
 		public ColumnList Columns = new ColumnList();
 		public List<Constraint> Constraints = new List<Constraint>();

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -125,7 +125,8 @@ end
 
 			var sql = new StringBuilder();
 			sql.Append("select ");
-			foreach (var c in Columns.Items.Where(c => string.IsNullOrEmpty(c.ComputedDefinition))) {
+			var cols = Columns.Items.Where(c => string.IsNullOrEmpty(c.ComputedDefinition)).ToArray();
+			foreach (var c in cols) {
 				sql.AppendFormat("[{0}],", c.Name);
 			}
 			sql.Remove(sql.Length - 1, 1);
@@ -138,7 +139,7 @@ end
 					cm.CommandText = sql.ToString();
 					using (var dr = cm.ExecuteReader()) {
 						while (dr.Read()) {
-							foreach (var c in Columns.Items) {
+							foreach (var c in cols) {
 								if (dr[c.Name] is DBNull)
 									data.Write(nullValue);
 								else if (dr[c.Name] is byte[])
@@ -147,7 +148,7 @@ end
 									data.Write(dr[c.Name].ToString()
 										.Replace(fieldSeparator, escapeFieldSeparator)
 										.Replace(rowSeparator, escapeRowSeparator));
-								if (c != Columns.Items.Last())
+								if (c != cols.Last())
 									data.Write(fieldSeparator);
 							}
 							data.WriteLine();
@@ -162,75 +163,85 @@ end
 				throw new InvalidOperationException();
 
 			var dt = new DataTable();
-			foreach (var c in Columns.Items.Where(c => string.IsNullOrEmpty(c.ComputedDefinition))) {
+			var cols = Columns.Items.Where(c => string.IsNullOrEmpty(c.ComputedDefinition)).ToArray();
+			foreach (var c in cols)
+			{
 				dt.Columns.Add(new DataColumn(c.Name, c.SqlTypeToNativeType()));
 			}
 
 			var linenumber = 0;
 			var batch_rows = 0;
-			SqlBulkCopy bulk;
+			using (var bulk = new SqlBulkCopy(conn, SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock))
+			{
+				foreach (var colName in dt.Columns.OfType<DataColumn>().Select(c => c.ColumnName))
+					bulk.ColumnMappings.Add(colName, colName);
+				bulk.DestinationTableName = string.Format("[{0}].[{1}]", Owner, Name);
 
-			using (var file = new StreamReader(filename)) {
-				var line = new List<char>();
-				while (file.Peek() >= 0) {
-					var rowsep_cnt = 0;
-					line.Clear();
+				using (var file = new StreamReader(filename))
+				{
+					var line = new List<char>();
+					while (file.Peek() >= 0)
+					{
+						var rowsep_cnt = 0;
+						line.Clear();
 
-					while (file.Peek() >= 0) {
-						var ch = (char) file.Read();
-						line.Add(ch);
+						while (file.Peek() >= 0)
+						{
+							var ch = (char)file.Read();
+							line.Add(ch);
 
-						if (ch == rowSeparator[rowsep_cnt])
-							rowsep_cnt++;
-						else
-							rowsep_cnt = 0;
+							if (ch == rowSeparator[rowsep_cnt])
+								rowsep_cnt++;
+							else
+								rowsep_cnt = 0;
 
-						if (rowsep_cnt == rowSeparator.Length) {
-							// Remove rowseparator from line
-							line.RemoveRange(line.Count - rowSeparator.Length, rowSeparator.Length);
-							break;
+							if (rowsep_cnt == rowSeparator.Length)
+							{
+								// Remove rowseparator from line
+								line.RemoveRange(line.Count - rowSeparator.Length, rowSeparator.Length);
+								break;
+							}
 						}
-					}
-					linenumber++;
+						linenumber++;
 
-					// Skip empty lines
-					if (line.Count == 0)
-						continue;
+						// Skip empty lines
+						if (line.Count == 0)
+							continue;
 
-					batch_rows ++;
+						batch_rows++;
 
-					var row = dt.NewRow();
-					var fields = (new String(line.ToArray())).Split(new[] {fieldSeparator}, StringSplitOptions.None);
-					if (fields.Length != dt.Columns.Count) {
-						throw new DataException("Incorrect number of columns", linenumber);
-					}
-					for (var j = 0; j < fields.Length; j++) {
-						try {
-							row[j] = ConvertType(Columns.Items[j].Type,
-								fields[j].Replace(escapeRowSeparator, rowSeparator).Replace(escapeFieldSeparator, fieldSeparator));
-						} catch (FormatException ex) {
-							throw new DataException(string.Format("{0} at column {1}", ex.Message, j + 1), linenumber);
+						var row = dt.NewRow();
+						var fields = (new String(line.ToArray())).Split(new[] { fieldSeparator }, StringSplitOptions.None);
+						if (fields.Length != dt.Columns.Count)
+						{
+							throw new DataException("Incorrect number of columns", linenumber);
 						}
-					}
-					dt.Rows.Add(row);
+						for (var j = 0; j < fields.Length; j++)
+						{
+							try
+							{
+								row[j] = ConvertType(cols[j].Type,
+									fields[j].Replace(escapeRowSeparator, rowSeparator).Replace(escapeFieldSeparator, fieldSeparator));
+							}
+							catch (FormatException ex)
+							{
+								throw new DataException(string.Format("{0} at column {1}", ex.Message, j + 1), linenumber);
+							}
+						}
+						dt.Rows.Add(row);
 
-					if (batch_rows == rowsInBatch) {
-						batch_rows = 0;
-						bulk = new SqlBulkCopy(conn,
-							SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock);
-						bulk.DestinationTableName = string.Format("[{0}].[{1}]", Owner, Name);
-						bulk.WriteToServer(dt);
-						bulk.Close();
-						dt.Clear();
+						if (batch_rows == rowsInBatch)
+						{
+							batch_rows = 0;
+							bulk.WriteToServer(dt);
+							dt.Clear();
+						}
 					}
 				}
-			}
 
-			bulk = new SqlBulkCopy(conn,
-				SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock);
-			bulk.DestinationTableName = string.Format("[{0}].[{1}]", Owner, Name);
-			bulk.WriteToServer(dt);
-			bulk.Close();
+				bulk.WriteToServer(dt);
+				bulk.Close();
+			}
 		}
 
 		public static object ConvertType(string sqlType, string val) {

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -261,6 +261,7 @@ end
 					return int.Parse(val);
 				case "uniqueidentifier":
 					return new Guid(val);
+				case "binary":
 				case "varbinary":
 				case "image":
 					return SoapHexBinary.Parse(val).Value;

--- a/test/ConfigHelper.cs
+++ b/test/ConfigHelper.cs
@@ -1,17 +1,23 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 
 namespace SchemaZen.test {
 	public class ConfigHelper {
 		public static string TestDB {
-			get { return ConfigurationManager.AppSettings["testdb"]; }
+			get { return GetSetting("testdb"); }
 		}
 
 		public static string TestSchemaDir {
-			get { return ConfigurationManager.AppSettings["test_schema_dir"]; }
+			get { return GetSetting("test_schema_dir"); }
 		}
 
 		public static string SqlDbDiffPath {
-			get { return ConfigurationManager.AppSettings["SqlDbDiffPath"]; }
+			get { return GetSetting("SqlDbDiffPath"); }
+		}
+
+		private static string GetSetting(string key) {
+			var val = Environment.GetEnvironmentVariable(key);
+			return val ?? ConfigurationManager.AppSettings[key];
 		}
 	}
 }

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -484,6 +484,11 @@ select * from Table1
 			db.Dir = db.Name;
 			db.Load();
 
+			if (Directory.Exists(db.Dir)) // if the directory exists, delete it to make it a fair test
+			{
+				Directory.Delete(db.Dir, true);
+			}
+
 			db.ScriptToDir();
 
 			Assert.AreEqual(0, db.Assemblies.Count);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -148,16 +148,16 @@ namespace SchemaZen.test {
 			var t1 = new Table("dbo", "t1");
 			t1.Columns.Add(new Column("col1", "int", false, null) {Position = 1});
 			t1.Columns.Add(new Column("col2", "int", false, null) {Position = 2});
-			t1.Constraints.Add(new Constraint("pk_t1", "PRIMARY KEY", "col1,col2"));
+			t1.AddConstraint(new Constraint("pk_t1", "PRIMARY KEY", "col1,col2"));
 			t1.FindConstraint("pk_t1").Clustered = true;
 
 			var t2 = new Table("dbo", "t2");
 			t2.Columns.Add(new Column("col1", "int", false, null) {Position = 1});
 			t2.Columns.Add(new Column("col2", "int", false, null) {Position = 2});
 			t2.Columns.Add(new Column("col3", "int", false, null) {Position = 3});
-			t2.Constraints.Add(new Constraint("pk_t2", "PRIMARY KEY", "col1"));
+			t2.AddConstraint(new Constraint("pk_t2", "PRIMARY KEY", "col1"));
 			t2.FindConstraint("pk_t2").Clustered = true;
-			t2.Constraints.Add(new Constraint("IX_col3", "UNIQUE", "col3"));
+			t2.AddConstraint(new Constraint("IX_col3", "UNIQUE", "col3"));
 
 			db.ForeignKeys.Add(new ForeignKey(t2, "fk_t2_t1", "col2,col3", t1, "col1,col2"));
 
@@ -372,26 +372,21 @@ select * from Table1
 			var policy = new Table("dbo", "Policy");
 			policy.Columns.Add(new Column("id", "int", false, null) {Position = 1});
 			policy.Columns.Add(new Column("form", "tinyint", false, null) {Position = 2});
-			policy.Constraints.Add(new Constraint("PK_Policy", "PRIMARY KEY", "id"));
-			policy.Constraints[0].Clustered = true;
-			policy.Constraints[0].Unique = true;
+			policy.AddConstraint(new Constraint("PK_Policy", "PRIMARY KEY", "id") { Clustered = true, Unique = true });
 			policy.Columns.Items[0].Identity = new Identity(1, 1);
 
 			var loc = new Table("dbo", "Location");
 			loc.Columns.Add(new Column("id", "int", false, null) {Position = 1});
 			loc.Columns.Add(new Column("policyId", "int", false, null) {Position = 2});
 			loc.Columns.Add(new Column("storage", "bit", false, null) {Position = 3});
-			loc.Constraints.Add(new Constraint("PK_Location", "PRIMARY KEY", "id"));
-			loc.Constraints[0].Clustered = true;
-			loc.Constraints[0].Unique = true;
+			loc.AddConstraint(new Constraint("PK_Location", "PRIMARY KEY", "id") { Clustered = true, Unique = true });
 			loc.Columns.Items[0].Identity = new Identity(1, 1);
 
 			var formType = new Table("dbo", "FormType");
 			formType.Columns.Add(new Column("code", "tinyint", false, null) {Position = 1});
 			formType.Columns.Add(new Column("desc", "varchar", 10, false, null) {Position = 2});
-			formType.Constraints.Add(new Constraint("PK_FormType", "PRIMARY KEY", "code"));
-			formType.Constraints[0].Clustered = true;
-
+			formType.AddConstraint(new Constraint("PK_FormType", "PRIMARY KEY", "code") { Clustered = true });
+			
 			var fk_policy_formType = new ForeignKey("FK_Policy_FormType");
 			fk_policy_formType.Table = policy;
 			fk_policy_formType.Columns.Add("form");
@@ -412,7 +407,7 @@ select * from Table1
 			tt_codedesc.IsType = true;
 			tt_codedesc.Columns.Add(new Column("code", "tinyint", false, null) { Position = 1 });
 			tt_codedesc.Columns.Add(new Column("desc", "varchar", 10, false, null) { Position = 2 });
-			tt_codedesc.Constraints.Add(new Constraint("PK_CodeDesc", "PRIMARY KEY", "code"));
+			tt_codedesc.AddConstraint(new Constraint("PK_CodeDesc", "PRIMARY KEY", "code"));
 
 			var db = new Database("ScriptToDirTest");
 			db.Tables.Add(policy);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -184,7 +184,8 @@ namespace SchemaZen.test {
 		public void TestScriptTableType() {
 			var setupSQL1 = @"
 CREATE TYPE [dbo].[MyTableType] AS TABLE(
-	[ID] [nvarchar](250) NULL
+	[ID] [nvarchar](250) NULL,
+	[Value] [numeric](5, 1) NULL
 )
 
 ";
@@ -204,6 +205,8 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 
 			Assert.AreEqual(1, db.TableTypes.Count());
 			Assert.AreEqual(250, db.TableTypes[0].Columns.Items[0].Length);
+			Assert.AreEqual(1, db.TableTypes[0].Columns.Items[1].Scale);
+			Assert.AreEqual(5, db.TableTypes[0].Columns.Items[1].Precision);
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
 			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
 

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -411,7 +411,7 @@ select * from Table1
 			db.Tables.Add(loc);
 			db.ForeignKeys.Add(fk_policy_formType);
 			db.ForeignKeys.Add(fk_location_policy);
-			db.FindProp("COMPATIBILITY_LEVEL").Value = "120";
+			db.FindProp("COMPATIBILITY_LEVEL").Value = "110";
 			db.FindProp("COLLATE").Value = "SQL_Latin1_General_CP1_CI_AS";
 			db.FindProp("AUTO_CLOSE").Value = "OFF";
 			db.FindProp("AUTO_SHRINK").Value = "ON";

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -408,10 +408,17 @@ select * from Table1
 			fk_location_policy.OnUpdate = "NO ACTION";
 			fk_location_policy.OnDelete = "CASCADE";
 
+			var tt_codedesc = new Table("dbo", "CodeDesc");
+			tt_codedesc.IsType = true;
+			tt_codedesc.Columns.Add(new Column("code", "tinyint", false, null) { Position = 1 });
+			tt_codedesc.Columns.Add(new Column("desc", "varchar", 10, false, null) { Position = 2 });
+			tt_codedesc.Constraints.Add(new Constraint("PK_CodeDesc", "PRIMARY KEY", "code"));
+
 			var db = new Database("ScriptToDirTest");
 			db.Tables.Add(policy);
 			db.Tables.Add(formType);
 			db.Tables.Add(loc);
+			db.TableTypes.Add(tt_codedesc);
 			db.ForeignKeys.Add(fk_policy_formType);
 			db.ForeignKeys.Add(fk_location_policy);
 			db.FindProp("COMPATIBILITY_LEVEL").Value = "110";
@@ -451,6 +458,10 @@ select * from Table1
 
 			db.DataTables.Add(formType);
 			db.Dir = db.Name;
+
+			if (Directory.Exists(db.Dir))
+				Directory.Delete(db.Dir, true);
+
 			db.ScriptToDir();
 			Assert.IsTrue(Directory.Exists(db.Name));
 			Assert.IsTrue(Directory.Exists(db.Name + "\\data"));
@@ -462,6 +473,9 @@ select * from Table1
 			}
 			foreach (var t in db.Tables) {
 				Assert.IsTrue(File.Exists(db.Name + "\\tables\\" + t.Name + ".sql"));
+			}
+			foreach (var t in db.TableTypes) {
+				Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_" + t.Name + ".sql"));
 			}
 			foreach (var expected in db.ForeignKeys.Select(fk => db.Name + "\\foreign_keys\\" + fk.Table.Name + ".sql")) {
 				Assert.IsTrue(File.Exists(expected), "File does not exist" + expected);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -471,5 +471,48 @@ select * from Table1
 			copy.Load();
 			TestCompare(db, copy);
 		}
+
+		[Test]
+		public void TestScriptToDirOnlyCreatesNecessaryFolders()
+		{
+			var db = new Database("TestEmptyDB");
+
+			db.Connection = ConfigHelper.TestDB.Replace("database=TESTDB", "database=" + db.Name);
+
+			db.ExecCreate(true);
+
+			db.Dir = db.Name;
+			db.Load();
+
+			db.ScriptToDir();
+
+			Assert.AreEqual(0, db.Assemblies.Count);
+			Assert.AreEqual(0, db.DataTables.Count);
+			Assert.AreEqual(0, db.ForeignKeys.Count);
+			Assert.AreEqual(0, db.Routines.Count);
+			Assert.AreEqual(0, db.Schemas.Count);
+			Assert.AreEqual(0, db.Synonyms.Count);
+			Assert.AreEqual(0, db.Tables.Count);
+			Assert.AreEqual(0, db.TableTypes.Count);
+			Assert.AreEqual(0, db.Users.Count);
+			Assert.AreEqual(0, db.ViewIndexes.Count);
+
+			Assert.IsTrue(Directory.Exists(db.Name));
+			Assert.IsTrue(File.Exists(db.Name + "\\props.sql"));
+			//Assert.IsFalse(File.Exists(db.Name + "\\schemas.sql"));
+
+			Assert.IsFalse(Directory.Exists(db.Name + "\\assemblies"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\data"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\foreign_keys"));
+			foreach (var routineType in Enum.GetNames(typeof(Routine.RoutineKind)))
+			{
+				var dir = routineType.ToLower() + "s";
+				Assert.IsFalse(Directory.Exists(db.Name + "\\" + dir));
+			}
+			Assert.IsFalse(Directory.Exists(db.Name + "\\synonyms"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\tables"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\table_types"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\users"));
+		}
 	}
 }

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -385,7 +385,7 @@ select * from Table1
 			var formType = new Table("dbo", "FormType");
 			formType.Columns.Add(new Column("code", "tinyint", false, null) {Position = 1});
 			formType.Columns.Add(new Column("desc", "varchar", 10, false, null) {Position = 2});
-			formType.AddConstraint(new Constraint("PK_FormType", "PRIMARY KEY", "code") { Clustered = true });
+			formType.AddConstraint(new Constraint("PK_FormType", "PRIMARY KEY", "code") { Clustered = true, Unique = true });
 			
 			var fk_policy_formType = new ForeignKey("FK_Policy_FormType");
 			fk_policy_formType.Table = policy;

--- a/test/ForeignKeyTester.cs
+++ b/test/ForeignKeyTester.cs
@@ -8,7 +8,7 @@ namespace SchemaZen.test {
 			var t1 = new Table("dbo", "t1");
 			t1.Columns.Add(new Column("c2", "varchar", 10, false, null));
 			t1.Columns.Add(new Column("c1", "int", false, null));
-			t1.Constraints.Add(new Constraint("pk_t1", "PRIMARY KEY", "c1,c2"));
+			t1.AddConstraint(new Constraint("pk_t1", "PRIMARY KEY", "c1,c2"));
 
 			var t2 = new Table("dbo", "t2");
 			t2.Columns.Add(new Column("c1", "int", false, null));
@@ -39,7 +39,7 @@ namespace SchemaZen.test {
 			person.Columns.Add(new Column("id", "int", false, null));
 			person.Columns.Add(new Column("name", "varchar", 50, false, null));
 			person.Columns.Find("id").Identity = new Identity(1, 1);
-			person.Constraints.Add(new Constraint("PK_Person", "PRIMARY KEY", "id"));
+			person.AddConstraint(new Constraint("PK_Person", "PRIMARY KEY", "id"));
 
 			var address = new Table("dbo", "Address");
 			address.Columns.Add(new Column("id", "int", false, null));
@@ -49,7 +49,7 @@ namespace SchemaZen.test {
 			address.Columns.Add(new Column("state", "char", 2, false, null));
 			address.Columns.Add(new Column("zip", "varchar", 5, false, null));
 			address.Columns.Find("id").Identity = new Identity(1, 1);
-			address.Constraints.Add(new Constraint("PK_Address", "PRIMARY KEY", "id"));
+			address.AddConstraint(new Constraint("PK_Address", "PRIMARY KEY", "id"));
 
 			var fk = new ForeignKey(address, "FK_Address_Person", "personId", person, "id", "", "CASCADE");
 

--- a/test/ProcTester.cs
+++ b/test/ProcTester.cs
@@ -13,7 +13,7 @@ namespace SchemaZen.test {
 			t.Columns.Add(new Column("city", "varchar", 50, false, null));
 			t.Columns.Add(new Column("state", "char", 2, false, null));
 			t.Columns.Add(new Column("zip", "char", 5, false, null));
-			t.Constraints.Add(new Constraint("PK_Address", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Address", "PRIMARY KEY", "id"));
 
 			var getAddress = new Routine("dbo", "GetAddress", null);
 			getAddress.Text = @"

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -34,8 +34,8 @@ namespace SchemaZen.test {
 			//test equal
 			t1.Columns.Add(new Column("first", "varchar", 30, false, null));
 			t2.Columns.Add(new Column("first", "varchar", 30, false, null));
-			t1.Constraints.Add(new Constraint("PK_Test", "PRIMARY KEY", "first"));
-			t2.Constraints.Add(new Constraint("PK_Test", "PRIMARY KEY", "first"));
+			t1.AddConstraint(new Constraint("PK_Test", "PRIMARY KEY", "first"));
+			t2.AddConstraint(new Constraint("PK_Test", "PRIMARY KEY", "first"));
 
 			diff = t1.Compare(t2);
 			Assert.IsNotNull(diff);
@@ -75,7 +75,7 @@ namespace SchemaZen.test {
 			t.Columns.Add(new Column("code", "char", 1, false, null));
 			t.Columns.Add(new Column("description", "varchar", 20, false, null));
 			t.Columns.Find("id").Identity = new Identity(1, 1);
-			t.Constraints.Add(new Constraint("PK_Status", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Status", "PRIMARY KEY", "id"));
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);
@@ -113,7 +113,7 @@ namespace SchemaZen.test {
 			computedCol.ComputedDefinition = "code + ' : ' + description";
 			t.Columns.Add(computedCol);
 			t.Columns.Find("id").Identity = new Identity(1, 1);
-			t.Constraints.Add(new Constraint("PK_Status", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Status", "PRIMARY KEY", "id"));
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);
@@ -151,7 +151,7 @@ namespace SchemaZen.test {
 			t.Columns.Add(new Column("code", "char", 1, false, null));
 			t.Columns.Add(new Column("description", "varchar", 20, false, null));
 			t.Columns.Find("id").Identity = new Identity(1, 1);
-			t.Constraints.Add(new Constraint("PK_Example", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Example", "PRIMARY KEY", "id"));
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);
@@ -186,8 +186,8 @@ namespace SchemaZen.test {
 		public void TestLargeAmountOfRowsImportAndExport() {
 			var t = new Table("dbo", "TestData");
 			t.Columns.Add(new Column("test_field", "int", false, null));
-			t.Constraints.Add(new Constraint("PK_TestData", "PRIMARY KEY", "test_field"));
-			t.Constraints.Add(new Constraint("IX_TestData_PK", "INDEX", "test_field") { Clustered = true, Table = t, Unique = true }); // clustered index is required to ensure the row order is the same as what we import
+			t.AddConstraint(new Constraint("PK_TestData", "PRIMARY KEY", "test_field"));
+			t.AddConstraint(new Constraint("IX_TestData_PK", "INDEX", "test_field") { Clustered = true, Table = t, Unique = true }); // clustered index is required to ensure the row order is the same as what we import
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -148,7 +148,7 @@ namespace SchemaZen.test {
 		}
 
 		[Test]
-		public void TestLargeAmountOfDataImport()
+		public void TestLargeAmountOfRowsImportAndExport()
 		{
 			var t = new Table("dbo", "TestData");
 			t.Columns.Add(new Column("test_field", "int", false, null));
@@ -176,7 +176,7 @@ namespace SchemaZen.test {
 			writer.Close();
 
 			var dataIn = sb.ToString();
-			Assert.AreEqual(dataIn, File.ReadAllText(filename)); // just check that the file and the string are the same, to make the next test meaningful!
+			Assert.AreEqual(dataIn, File.ReadAllText(filename)); // just prove that the file and the string are the same, to make the next assertion meaningful!
 			
 			try
 			{

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -104,8 +104,7 @@ namespace SchemaZen.test {
 		}
 
 		[Test]
-		public void TestImportAndExportIgnoringComputedData()
-		{
+		public void TestImportAndExportIgnoringComputedData() {
 			var t = new Table("dbo", "Status");
 			t.Columns.Add(new Column("id", "int", false, null));
 			t.Columns.Add(new Column("code", "char", 1, false, null));
@@ -134,22 +133,18 @@ namespace SchemaZen.test {
 			writer.Flush();
 			writer.Close();
 
-			try
-			{
+			try {
 				t.ImportData(conn, filename);
 				var sw = new StringWriter();
 				t.ExportData(conn, sw);
 				Assert.AreEqual(dataIn, sw.ToString());
-			}
-			finally
-			{
+			} finally {
 				File.Delete(filename);
 			}
 		}
 
 		[Test]
-		public void TestImportAndExportNonDefaultSchema()
-		{
+		public void TestImportAndExportNonDefaultSchema() {
 			var s = new Schema("example", "dbo");
 			var t = new Table(s.Name, "Example");
 			t.Columns.Add(new Column("id", "int", false, null));
@@ -177,22 +172,18 @@ namespace SchemaZen.test {
 			writer.Flush();
 			writer.Close();
 
-			try
-			{
+			try {
 				t.ImportData(conn, filename);
 				var sw = new StringWriter();
 				t.ExportData(conn, sw);
 				Assert.AreEqual(dataIn, sw.ToString());
-			}
-			finally
-			{
+			} finally {
 				File.Delete(filename);
 			}
 		}
 
 		[Test]
-		public void TestLargeAmountOfRowsImportAndExport()
-		{
+		public void TestLargeAmountOfRowsImportAndExport() {
 			var t = new Table("dbo", "TestData");
 			t.Columns.Add(new Column("test_field", "int", false, null));
 			t.Constraints.Add(new Constraint("PK_TestData", "PRIMARY KEY", "test_field"));
@@ -209,8 +200,7 @@ namespace SchemaZen.test {
 			var writer = File.CreateText(filename);
 			StringBuilder sb = new StringBuilder();
 
-			for (var i = 0; i < Table.rowsInBatch * 4.2; i++)
-			{
+			for (var i = 0; i < Table.rowsInBatch * 4.2; i++) {
 				sb.AppendLine(i.ToString());
 				writer.WriteLine(i.ToString());
 			}
@@ -220,17 +210,14 @@ namespace SchemaZen.test {
 
 			var dataIn = sb.ToString();
 			Assert.AreEqual(dataIn, File.ReadAllText(filename)); // just prove that the file and the string are the same, to make the next assertion meaningful!
-			
-			try
-			{
+
+			try {
 				t.ImportData(conn, filename);
 				var sw = new StringWriter();
 				t.ExportData(conn, sw);
 
 				Assert.AreEqual(dataIn, sw.ToString());
-			}
-			finally
-			{
+			} finally {
 				File.Delete(filename);
 			}
 		}
@@ -275,7 +262,7 @@ namespace SchemaZen.test {
 		}
 
 		[Test]
-		[ExpectedException(typeof (NotSupportedException))]
+		[ExpectedException(typeof(NotSupportedException))]
 		public void TestScriptNonSupportedColumn() {
 			var t = new Table("dbo", "bla");
 			t.Columns.Add(new Column("a", "madeuptype", true, null));

--- a/test/packages.config
+++ b/test/packages.config
@@ -2,4 +2,5 @@
 
 <packages>
   <package id="NUnit" version="2.6.2" targetFramework="net35" />
+  <package id="NUnit.Runners" version="2.6.2" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Hi Seth,

I have modified the `DatabaseTester.TestScriptToDir` test to include scripting a user defined table type to prove that it currently doesn't work properly - at the moment, the test fails. This relates to issue #57.

I have then made two fixes:
- one is to include the `table_types` directory in the `dirs` variable in the `Database` class, to ensure that it executes the scripts in this folder in create mode.
- the second is to only script a `Constraint`s name when the table it applies to is not a table type. As part of this fix, I changed the way constraints are added to a table, to ensure that the `Table` field is always set, previously it wasn't being set from the tests. Because table type constraints don't have names in the script, I also had to change the way constraints are compared for table types, to show that the related tables are successful.

All in all, these changes turn this failing test back to green.
